### PR TITLE
Fix typing on convert classmethod to work with subclassing

### DIFF
--- a/typedframe/typedframe.py
+++ b/typedframe/typedframe.py
@@ -98,7 +98,7 @@ class TypedDataFrame:
                     df[col] = pd.to_datetime(df[col], utc=True)
                 else:
                     df[col] = df[col].astype(expected[col])
-
+        
         if cls.index_schema[1]:
             df.index = df.index.astype(cls.index_schema[1])
             df.index.name = cls.index_schema[0]
@@ -137,7 +137,7 @@ class TypedDataFrame:
                     diff.add((col, dtype))
             except TypeError:
                 diff.add((col, dtype))
-
+        
         if self.index_schema[1]:
             if df.index.name != self.index_schema[0]:
                 diff.add(f"expected index name {self.index_schema[0]}, actual index name {df.index.name}")
@@ -184,7 +184,7 @@ def _normalize_expected_dtype(dtype):
         else:
             return dtype
     except TypeError:
-        return dtype
+        return dtype 
 
 
 def _dtypes_dismatch(actual, expected) -> bool:

--- a/typedframe/typedframe.py
+++ b/typedframe/typedframe.py
@@ -2,6 +2,7 @@
 Basic classes for typed wrappers over pandas dataframes
 """
 from itertools import chain
+from typing import Type, TypeVar
 import pytz
 
 import numpy as np
@@ -18,6 +19,7 @@ dtype for datetime column
 DATE_TIME_DTYPE = np.dtype('datetime64[ns]')
 UTC_DATE_TIME_DTYPE = pd.DatetimeTZDtype('ns', pytz.UTC)
 
+T = TypeVar("T", bound="TypedDataFrame")
 
 class TypedDataFrame:
     """
@@ -57,7 +59,7 @@ class TypedDataFrame:
     optional = {}
 
     @classmethod
-    def convert(cls, df: pd.DataFrame) -> 'TypedDataFrame':
+    def convert(cls: Type[T], df: pd.DataFrame) -> T:
         """
         Tries to convert a given dataframe and wrap in a typed dataframe.
 
@@ -96,7 +98,7 @@ class TypedDataFrame:
                     df[col] = pd.to_datetime(df[col], utc=True)
                 else:
                     df[col] = df[col].astype(expected[col])
-        
+
         if cls.index_schema[1]:
             df.index = df.index.astype(cls.index_schema[1])
             df.index.name = cls.index_schema[0]
@@ -135,7 +137,7 @@ class TypedDataFrame:
                     diff.add((col, dtype))
             except TypeError:
                 diff.add((col, dtype))
-        
+
         if self.index_schema[1]:
             if df.index.name != self.index_schema[0]:
                 diff.add(f"expected index name {self.index_schema[0]}, actual index name {df.index.name}")
@@ -182,7 +184,7 @@ def _normalize_expected_dtype(dtype):
         else:
             return dtype
     except TypeError:
-        return dtype 
+        return dtype
 
 
 def _dtypes_dismatch(actual, expected) -> bool:


### PR DESCRIPTION
The `convert` classmethod needs to use a TypeVar for subclasses to be typed properly.