### PR TITLE
Handle list and dict types

### DIFF
--- a/tests/test_pandas_typedframe.py
+++ b/tests/test_pandas_typedframe.py
@@ -224,3 +224,23 @@ def test_multiple_inheritance_2_failure():
 def test_multiple_inheritance_2_failure_with_root_overwrite():
     with pytest.raises(AssertionError):
         _ = Down(pd.DataFrame({'root': [True], 'left': [True], 'right': ['string']}))
+
+
+class ListFrame(TypedDataFrame):
+    schema = {
+        'col1': list
+    }
+
+
+def test_convert_list_attribute_type():
+    _ = ListFrame.convert(pd.DataFrame({'col1': [["this"]]}))
+
+
+class DictFrame(TypedDataFrame):
+    schema = {
+        'col1': dict
+    }
+
+
+def test_convert_dict_attribute_type():
+    _ = DictFrame.convert(pd.DataFrame({'col1': [{"this": "that"}]}))

--- a/tests/test_polars_typedframe.py
+++ b/tests/test_polars_typedframe.py
@@ -47,7 +47,7 @@ def test_base_success_case():
                        'datetime_field': [datetime.datetime(2021, 5, 31, 12, 0, 0), datetime.datetime(2021, 6, 1, 12, 0, 0), datetime.datetime(2021, 6, 2, 12, 0, 0)],
                        'mixin_field': [1, 2, 3],
                        'new_field': [1, 2, 3]})
-    df = df.with_column(pl.col('int_field').cast(pl.Int16))
+    df = df.with_columns(pl.col('int_field').cast(pl.Int16))
     _ = ChildDataFrame(df)
 
 

--- a/typedframe/pandas_.py
+++ b/typedframe/pandas_.py
@@ -72,6 +72,8 @@ class PandasTypedFrame(TypedDataFrameBase):
                         if categories_diff:
                             raise AssertionError(f"For column: {col} there are unknown categories: {categories_diff}")
                         df[col] = pd.Categorical(df[col], categories=expected[col], ordered=True)
+                    elif expected[col] in (list, dict):
+                        df[col] = expected[col](df[col])
                     elif expected[col] == DATE_TIME_DTYPE:
                         df[col] = pd.to_datetime(df[col])
                     elif expected[col] == UTC_DATE_TIME_DTYPE:


### PR DESCRIPTION
⚠️ NB This PR also includes the commit from #10 and #11 which should be merged first, we cna then rebase this PR. 

In the documentation we read that

> str, dict, list, object

[are supported types](https://typedframe.readthedocs.io/en/latest/index.html#python-objects), but defining a `list` or `dict` type results in an `AssertionError` (see #9 )

This PR introduces a fix where the type of the column is checked, and if it's `list` or `dict` then cast / convert directly. 
(I would have preferred a more generic solution, but these were getting more complicated). 

Two new tests have been added to cover this case. 